### PR TITLE
ログイン前カートをログイン後ユーザーにマージ

### DIFF
--- a/backend/src/main/java/com/example/controller/OrderController.java
+++ b/backend/src/main/java/com/example/controller/OrderController.java
@@ -23,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,10 +48,11 @@ public class OrderController {
    * @return 全ての注文のリスト
    */
   @PostMapping
+  @Transactional
   public ResponseEntity<?> createOrder(
       @RequestBody OrderRequest request, @AuthenticationPrincipal Jwt jwt)
       throws MessagingException {
-    // 　注文情報を登録
+    // 注文情報を登録
     Order order = new Order();
     BeanUtils.copyProperties(request, order);
     order.setOrderDateTime(LocalDateTime.now());

--- a/backend/src/main/java/com/example/model/User.java
+++ b/backend/src/main/java/com/example/model/User.java
@@ -38,6 +38,7 @@ public class User {
 
   /** パスワードハッシュ. */
   @Column(name = "password", nullable = false, length = 255)
+  @JsonIgnore
   private String password;
 
   /** 郵便番号. */

--- a/backend/src/main/java/com/example/repository/CartProductRepository.java
+++ b/backend/src/main/java/com/example/repository/CartProductRepository.java
@@ -9,7 +9,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 /** 商品カートエンティティのリポジトリインターフェース. */
 public interface CartProductRepository extends JpaRepository<CartProduct, Integer> {
   /**
-   * ユーザIDに紐づくカート内商品を取得するメソッド.
+   * セッションIDに紐づくカート内商品を取得する.
+   *
+   * <p>ログイン時にカートをマージする時のみ使用、ソートが必要なく単にデータが欲しいため
+   *
+   * @param sessionId セッションID
+   * @return カート内商品
+   */
+  List<CartProduct> findBySessionId(String sessionId);
+
+  /**
+   * ユーザIDに紐づくカート内商品を取得する.
    *
    * @param user ユーザ
    * @return カート内商品リスト
@@ -17,7 +27,7 @@ public interface CartProductRepository extends JpaRepository<CartProduct, Intege
   List<CartProduct> findByUserIdOrderByCartProductIdDesc(User user);
 
   /**
-   * ユーザID、商品ID、商品カテゴリに紐づくカート内商品を取得するメソッド.
+   * ユーザID、商品ID、商品カテゴリに紐づくカート内商品を取得する.
    *
    * <p>userIdで比較する場合は、UserIdUserIdとする必要があるため注意.
    *
@@ -28,4 +38,23 @@ public interface CartProductRepository extends JpaRepository<CartProduct, Intege
    */
   Optional<CartProduct> findByUserIdUserIdAndProductIdAndProductCategory(
       Integer userId, Integer productId, Integer productCategory);
+
+  /**
+   * セッションIDに紐づくカート内商品を取得する.
+   *
+   * @param sessionId セッションID
+   * @return カート内商品リスト
+   */
+  List<CartProduct> findBySessionIdOrderByCartProductIdDesc(String sessionId);
+
+  /**
+   * セッションID、商品ID、商品カテゴリに紐づくカート内商品を取得する.
+   *
+   * @param sessionId セッションID
+   * @param productId 商品ID
+   * @param productCategory 商品カテゴリ
+   * @return カート内商品
+   */
+  Optional<CartProduct> findBySessionIdAndProductIdAndProductCategory(
+      String sessionId, Integer productId, Integer productCategory);
 }

--- a/frontend/src/features/cart/CartPage.tsx
+++ b/frontend/src/features/cart/CartPage.tsx
@@ -69,7 +69,7 @@ function CartPage() {
 
       fetchCartProducts();
     },
-    300, // 300ms
+    200, // 200ms
   );
 
   const handleDelete = async (cartProductId: number) => {


### PR DESCRIPTION
## PRに関連するissue
<!-- PRとともに、issueを閉じたい場合は"close #{issue番号}"で閉じることが可能 -->

## やったこと
<!-- このPR内でやったことを記載 -->
- ログイン前はsessionIdでカート内商品を管理する
- ログイン時にsessionIdで紐づけられたカート商品を取得し、ユーザーと紐づける（jwtトークン生成との一貫性を保つために@Transactionalを付与）
- 注文時、メール送信が失敗しても注文登録がされてしまう問題を、OrderControllerに@Transactionalをつけることで解消
## 
<!-- このPR内で特にレビューしてほしいところ、レビューをする上で参考になる情報を記載 -->
- 